### PR TITLE
Feature/14 improve readmes for each module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # mpulse-technical-assessment
-Terraform templates for standing up AWS resources. 
+Terraform modules for standing up AWS resources. 
+
+To run, you will need to provide three variables:
+1. deployer_public_key - A public SSH key to be used to SSH into the "ec2_public" instance
+2. inbound_ssh_ip - An IP or block of IPs, expressed in CIDR notation(Ex. X.X.X.X/32), that the "ec2_public" instance allows SSH traffic in from. 
+3. db_password - The password used for the database master user in the Postgres DB
+
+Other variables can be set as well, but either have logical defaults set or use outputs from another module.
+
+## Features
+- Creates base VPC network with two subnets for each category: Public, Private, and Database
+- Stands up two EC2 instances, ec2_private and ec2_public, with SSH access to ec2_public configured via variables
+- Builds a Postgres 13.6 database within the Database subnet group
+- Deploys two Lambda functions for scheduling the "ec2_public" instance. One to stop the instance and the other to start it.
 
 # Technical Assessment Details
 # Create AWS Resources using Terraform

--- a/modules/aws_network/README.md
+++ b/modules/aws_network/README.md
@@ -1,0 +1,2 @@
+# aws_network module
+Terraform module that creates VPC resources, including two subnets for each category: Public, Private, and Database.

--- a/modules/aws_resources/README.md
+++ b/modules/aws_resources/README.md
@@ -1,0 +1,2 @@
+# aws_resources module
+Terraform module that creates EC2, RDS, and Lambda resources

--- a/modules/aws_resources/main.tf
+++ b/modules/aws_resources/main.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 provider "aws" {
+  default_tags {
+    tags = var.default_tags
+  }
   region = var.region
 }
 

--- a/modules/aws_resources/variables.tf
+++ b/modules/aws_resources/variables.tf
@@ -28,6 +28,16 @@ variable "ec2_scheduler_triggers" {
   }
 }
 
+variable "default_tags" {
+  default = {
+    Environment = "dev"
+    Owner       = "Jeremy"
+    Terraform   = "true"
+  }
+  description = "Default tags to apply to resources"
+  type        = map(string)
+}
+
 # Networking vars
 variable "region" {
   default     = "us-west-2"


### PR DESCRIPTION
- Improved the README for the root module with some additional info on how to run it and what it creates
- Added a basic README to each module
- Noticed that the aws_resources module was missing the "default_tags" I had applied to aws_network. Since this falls under a similar documentation umbrella, I added this change here.